### PR TITLE
fix: Update SpongePowered Repo Protocol.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
         maven {
             name = 'SpongePowered'
-            url = 'http://repo.spongepowered.org/maven'
+            url = 'https://repo.spongepowered.org/maven'
         }
         maven {
             name = "jitpack.io"
@@ -46,7 +46,7 @@ repositories {
     mavenCentral()
     maven {
         name = 'spongepowered-repo'
-        url = 'http://repo.spongepowered.org/maven/'
+        url = 'https://repo.spongepowered.org/maven/'
     }
     jcenter()
 }


### PR DESCRIPTION
SpongePowered have migrated their maven repository to a Sonatype Nexus instance. They do not support http protocol anymore. This commit should fix any future issues from importing the SpongePowered maven repository via Gradle.